### PR TITLE
Fix GitHub App authentication for posting PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 - **Database**: PostgreSQL 15
 - **ORM**: SQLAlchemy 2.0
 - **Migrations**: Alembic
+- **Task Queue**: Celery with Redis broker
 - **Cache/Queue**: Redis 7
+- **Orchestration**: Kubernetes
 - **Container**: Docker & Docker Compose
 
 ## License

--- a/api/app/services/github.py
+++ b/api/app/services/github.py
@@ -41,18 +41,14 @@ class GitHubService:
         Returns:
             Authenticated PyGithub client or None if not configured
         """
-        if not self.private_key:
-            logger.error("Cannot create GitHub client: private key not configured")
+        if not self.integration:
+            logger.error("Cannot create GitHub client: GitHub integration not configured")
             return None
 
-        # Get installation access token
-        auth = Auth.AppInstallationAuth(
-            app_id=self.app_id,
-            private_key=self.private_key,
-            installation_id=installation_id
-        )
+        # Get installation access token using integration
+        token = self.integration.get_access_token(installation_id).token
 
-        return Github(auth=auth)
+        return Github(token)
 
     def post_comment_to_pr(
         self,


### PR DESCRIPTION
- Fix AppInstallationAuth API to use GithubIntegration.get_access_token()
- Add get_environment() alias in CRUD for backward compatibility
- Update tech stack in README

This fixes the GitHub comment posting functionality.